### PR TITLE
Override sapling ... Fix change

### DIFF
--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -620,6 +620,7 @@ where
             &step_results,
             step,
             None,
+            None,
         )?;
         step_results.push((step, step_result));
     }
@@ -650,6 +651,7 @@ pub fn calculate_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, N>(
     usk_to_tkey: Option<
         fn(&UnifiedSpendingKey, &TransparentAddressMetadata) -> hdwallet::secp256k1::SecretKey,
     >,
+    override_sapling_change_address: Option<sapling::PaymentAddress>,
 ) -> Result<
     BuildResult,
     Error<
@@ -1034,7 +1036,7 @@ where
             ShieldedProtocol::Sapling => {
                 builder.add_sapling_output(
                     sapling_internal_ovk(),
-                    sapling_dfvk.change_address().1,
+                    override_sapling_change_address.unwrap_or(sapling_dfvk.change_address().1),
                     change_value.value(),
                     memo.clone(),
                 )?;

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -203,15 +203,7 @@ where
     })?;
 
     if proposed_change.is_zero() {
-        TransactionBalance::new(
-            vec![ChangeValue::new(
-                _fallback_change_pool,
-                NonNegativeAmount::const_from_u64(0),
-                change_memo,
-            )],
-            fee_amount,
-        )
-        .map_err(|_| overflow())
+        TransactionBalance::new(vec![], fee_amount).map_err(|_| overflow())
     } else {
         let dust_threshold = dust_output_policy
             .dust_threshold()


### PR DESCRIPTION
these are two seperate changes. the change to wallet.rs is old and fixed the sapling change address.

the change to common.rs reverts a zingolib change that im about to investigate by blame (i know it was me but what did my commit message say)

we need to get this repo better organized. we should be merging these changes into dev as branches, just like in zingolib