### PR TITLE
release zcash_client_sqlite version 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6078,7 +6078,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.12.2"
+version = "0.11.2"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.77.0"
 repository = "https://github.com/zcash/librustzcash"
 license = "MIT OR Apache-2.0"
 categories = ["cryptography::cryptocurrencies"]

--- a/components/zcash_address/src/encoding.rs
+++ b/components/zcash_address/src/encoding.rs
@@ -8,7 +8,7 @@ use crate::kind::unified::Encoding;
 use crate::{kind::*, AddressKind, ZcashAddress};
 
 /// An error while attempting to parse a string as a Zcash address.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ParseError {
     /// The string is an invalid encoding.
     InvalidEncoding,

--- a/components/zcash_address/src/kind/unified.rs
+++ b/components/zcash_address/src/kind/unified.rs
@@ -118,7 +118,7 @@ impl Typecode {
 }
 
 /// An error while attempting to parse a string as a Zcash address.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ParseError {
     /// The unified container contains both P2PKH and P2SH items.
     BothP2phkAndP2sh,

--- a/components/zcash_address/src/lib.rs
+++ b/components/zcash_address/src/lib.rs
@@ -154,7 +154,7 @@ pub struct ZcashAddress {
 
 /// Known kinds of Zcash addresses.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-enum AddressKind {
+pub enum AddressKind {
     Sprout([u8; 64]),
     Sapling([u8; 43]),
     Unified(unified::Address),
@@ -163,7 +163,21 @@ enum AddressKind {
     Tex([u8; 20]),
 }
 
+impl AddressKind {
+    pub fn get_unified_address(&self) -> Option<unified::Address> {
+        if let AddressKind::Unified(ua) = self {
+            Some(ua.clone())
+        } else {
+            None
+        }
+    }
+}
+
 impl ZcashAddress {
+    pub fn kind(&self) -> &AddressKind {
+        &self.kind
+    }
+
     /// Encodes this Zcash address in its canonical string representation.
     ///
     /// This provides the encoded string representation of the address as defined by the

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -272,6 +272,13 @@ user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
 
+[[publisher.zcash_client_sqlite]]
+version = "0.11.1"
+when = "2024-08-21"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_encoding]]
 version = "0.2.0"
 when = "2022-10-19"

--- a/zcash_client_backend/build.rs
+++ b/zcash_client_backend/build.rs
@@ -43,7 +43,7 @@ fn build() -> io::Result<()> {
 
     // Build the gRPC types and client.
     tonic_build::configure()
-        .build_server(false)
+        .build_server(true)
         .client_mod_attribute(
             "cash.z.wallet.sdk.rpc",
             r#"#[cfg(feature = "lightwalletd-tonic")]"#,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -140,8 +140,19 @@ pub type ProposeShieldingErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT> = Error
     Infallible,
 >;
 
-/// Errors that may be generated in combined creation and execution of transaction proposals.
-pub type CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N> = Error<
+    create_proposed_transactions(
+        wallet_db,
+        params,
+        spend_prover,
+        output_prover,
+        usk,
+        ovk_policy,
+        &proposal,
+        None,
+    )
+}
+
+type ErrorT<DbT, InputsErrT, FeeRuleT> = Error<
     <DbT as WalletRead>::Error,
     <DbT as WalletCommitmentTrees>::Error,
     InputsErrT,
@@ -160,16 +171,26 @@ pub type TransferErrT<DbT, InputsT, ChangeT> = Error<
     <<InputsT as InputSelector>::InputSource as InputSource>::NoteRef,
 >;
 
-/// Errors that may be generated in the execution of shielding proposals.
-#[cfg(feature = "transparent-inputs")]
-pub type ShieldErrT<DbT, InputsT, ChangeT> = Error<
-    <DbT as WalletRead>::Error,
-    <DbT as WalletCommitmentTrees>::Error,
-    <InputsT as ShieldingSelector>::Error,
-    <<ChangeT as ChangeStrategy>::FeeRule as FeeRule>::Error,
-    <ChangeT as ChangeStrategy>::Error,
-    Infallible,
->;
+    let proposal = propose_transfer(
+        wallet_db,
+        params,
+        account.id(),
+        input_selector,
+        request,
+        min_confirmations,
+    )?;
+
+    create_proposed_transactions(
+        wallet_db,
+        params,
+        spend_prover,
+        output_prover,
+        usk,
+        ovk_policy,
+        &proposal,
+        None,
+    )
+}
 
 /// Select transaction inputs, compute fees, and construct a proposal for a transaction or series
 /// of transactions that can then be authorized and made ready for submission to the network with
@@ -373,7 +394,8 @@ pub fn create_proposed_transactions<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeEr
     usk: &UnifiedSpendingKey,
     ovk_policy: OvkPolicy,
     proposal: &Proposal<FeeRuleT, N>,
-) -> Result<NonEmpty<TxId>, CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>>
+    override_sapling_change_address: Option<sapling::PaymentAddress>,
+) -> Result<NonEmpty<TxId>, ErrorT<DbT, InputsErrT, FeeRuleT>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
     ParamsT: consensus::Parameters + Clone,
@@ -407,6 +429,7 @@ where
             step,
             #[cfg(feature = "transparent-inputs")]
             &mut unused_transparent_outputs,
+            override_sapling_change_address,
         )?;
         step_results.push((step, step_result));
     }
@@ -473,10 +496,8 @@ fn create_proposed_transaction<DbT, ParamsT, InputsErrT, FeeRuleT, ChangeErrT, N
         StepOutput,
         (TransparentAddress, OutPoint),
     >,
-) -> Result<
-    StepResult<<DbT as WalletRead>::AccountId>,
-    CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N>,
->
+    override_sapling_change_address: Option<sapling::PaymentAddress>,
+) -> Result<StepResult<<DbT as WalletRead>::AccountId>, ErrorT<DbT, InputsErrT, FeeRuleT>>
 where
     DbT: WalletWrite + WalletCommitmentTrees,
     ParamsT: consensus::Parameters + Clone,
@@ -683,9 +704,8 @@ where
                 utxos_spent.push(outpoint.clone());
                 builder.add_transparent_input(secret_key, outpoint, txout)?;
 
-                Ok(())
-            };
-
+            Ok(())
+        };
         for utxo in proposal_step.transparent_inputs() {
             add_transparent_input(
                 &mut builder,
@@ -917,7 +937,7 @@ where
             PoolType::Shielded(ShieldedProtocol::Sapling) => {
                 builder.add_sapling_output(
                     sapling_internal_ovk(),
-                    sapling_dfvk.change_address().1,
+                    override_sapling_change_address.unwrap_or(sapling_dfvk.change_address().1),
                     change_value.value(),
                     memo.clone(),
                 )?;
@@ -939,7 +959,7 @@ where
                 {
                     builder.add_orchard_output(
                         orchard_internal_ovk(),
-                        orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal),
+                        orchard_fvk.address_at(0u32, orchard::keys::Scope::External),
                         change_value.value().into(),
                         memo.clone(),
                     )?;
@@ -1005,7 +1025,7 @@ where
     let build_result = builder.build(OsRng, spend_prover, output_prover, fee_rule)?;
 
     #[cfg(feature = "orchard")]
-    let orchard_internal_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::Internal);
+    let orchard_internal_ivk = orchard_fvk.to_ivk(orchard::keys::Scope::External);
     #[cfg(feature = "orchard")]
     let orchard_outputs =
         orchard_output_meta
@@ -1030,13 +1050,13 @@ where
                             })
                     })
                     .internal_account_note_transpose_option()
-                    .expect("Wallet-internal outputs must be decryptable with the wallet's IVK");
+                    .expect("Wallet-external outputs must be decryptable with the wallet's IVK");
 
                 SentTransactionOutput::from_parts(output_index, recipient, value, memo)
             });
 
     let sapling_internal_ivk =
-        PreparedIncomingViewingKey::new(&sapling_dfvk.to_ivk(Scope::Internal));
+        PreparedIncomingViewingKey::new(&sapling_dfvk.to_ivk(Scope::External));
     let sapling_outputs =
         sapling_output_meta
             .into_iter()
@@ -1063,7 +1083,7 @@ where
                             })
                     })
                     .internal_account_note_transpose_option()
-                    .expect("Wallet-internal outputs must be decryptable with the wallet's IVK");
+                    .expect("Wallet-external outputs must be decryptable with the wallet's IVK");
 
                 SentTransactionOutput::from_parts(output_index, recipient, value, memo)
             });
@@ -1185,5 +1205,6 @@ where
         usk,
         OvkPolicy::Sender,
         &proposal,
+        None,
     )
 }

--- a/zcash_client_backend/src/proto/service.rs
+++ b/zcash_client_backend/src/proto/service.rs
@@ -928,3 +928,1204 @@ pub mod compact_tx_streamer_client {
         }
     }
 }
+/// Generated server implementations.
+pub mod compact_tx_streamer_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with CompactTxStreamerServer.
+    #[async_trait]
+    pub trait CompactTxStreamer: Send + Sync + 'static {
+        /// Return the BlockID of the block at the tip of the best chain
+        async fn get_latest_block(
+            &self,
+            request: tonic::Request<super::ChainSpec>,
+        ) -> std::result::Result<tonic::Response<super::BlockId>, tonic::Status>;
+        /// Return the compact block corresponding to the given block identifier
+        async fn get_block(
+            &self,
+            request: tonic::Request<super::BlockId>,
+        ) -> std::result::Result<
+            tonic::Response<crate::proto::compact_formats::CompactBlock>,
+            tonic::Status,
+        >;
+        /// Same as GetBlock except actions contain only nullifiers
+        async fn get_block_nullifiers(
+            &self,
+            request: tonic::Request<super::BlockId>,
+        ) -> std::result::Result<
+            tonic::Response<crate::proto::compact_formats::CompactBlock>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the GetBlockRange method.
+        type GetBlockRangeStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    crate::proto::compact_formats::CompactBlock,
+                    tonic::Status,
+                >,
+            >
+            + Send
+            + 'static;
+        /// Return a list of consecutive compact blocks
+        async fn get_block_range(
+            &self,
+            request: tonic::Request<super::BlockRange>,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetBlockRangeStream>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the GetBlockRangeNullifiers method.
+        type GetBlockRangeNullifiersStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    crate::proto::compact_formats::CompactBlock,
+                    tonic::Status,
+                >,
+            >
+            + Send
+            + 'static;
+        /// Same as GetBlockRange except actions contain only nullifiers
+        async fn get_block_range_nullifiers(
+            &self,
+            request: tonic::Request<super::BlockRange>,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetBlockRangeNullifiersStream>,
+            tonic::Status,
+        >;
+        /// Return the requested full (not compact) transaction (as from zcashd)
+        async fn get_transaction(
+            &self,
+            request: tonic::Request<super::TxFilter>,
+        ) -> std::result::Result<tonic::Response<super::RawTransaction>, tonic::Status>;
+        /// Submit the given transaction to the Zcash network
+        async fn send_transaction(
+            &self,
+            request: tonic::Request<super::RawTransaction>,
+        ) -> std::result::Result<tonic::Response<super::SendResponse>, tonic::Status>;
+        /// Server streaming response type for the GetTaddressTxids method.
+        type GetTaddressTxidsStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::RawTransaction, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        /// Return the txids corresponding to the given t-address within the given block range
+        async fn get_taddress_txids(
+            &self,
+            request: tonic::Request<super::TransparentAddressBlockFilter>,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetTaddressTxidsStream>,
+            tonic::Status,
+        >;
+        async fn get_taddress_balance(
+            &self,
+            request: tonic::Request<super::AddressList>,
+        ) -> std::result::Result<tonic::Response<super::Balance>, tonic::Status>;
+        async fn get_taddress_balance_stream(
+            &self,
+            request: tonic::Request<tonic::Streaming<super::Address>>,
+        ) -> std::result::Result<tonic::Response<super::Balance>, tonic::Status>;
+        /// Server streaming response type for the GetMempoolTx method.
+        type GetMempoolTxStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    crate::proto::compact_formats::CompactTx,
+                    tonic::Status,
+                >,
+            >
+            + Send
+            + 'static;
+        /// Return the compact transactions currently in the mempool; the results
+        /// can be a few seconds out of date. If the Exclude list is empty, return
+        /// all transactions; otherwise return all *except* those in the Exclude list
+        /// (if any); this allows the client to avoid receiving transactions that it
+        /// already has (from an earlier call to this rpc). The transaction IDs in the
+        /// Exclude list can be shortened to any number of bytes to make the request
+        /// more bandwidth-efficient; if two or more transactions in the mempool
+        /// match a shortened txid, they are all sent (none is excluded). Transactions
+        /// in the exclude list that don't exist in the mempool are ignored.
+        async fn get_mempool_tx(
+            &self,
+            request: tonic::Request<super::Exclude>,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetMempoolTxStream>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the GetMempoolStream method.
+        type GetMempoolStreamStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::RawTransaction, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        /// Return a stream of current Mempool transactions. This will keep the output stream open while
+        /// there are mempool transactions. It will close the returned stream when a new block is mined.
+        async fn get_mempool_stream(
+            &self,
+            request: tonic::Request<super::Empty>,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetMempoolStreamStream>,
+            tonic::Status,
+        >;
+        /// GetTreeState returns the note commitment tree state corresponding to the given block.
+        /// See section 3.7 of the Zcash protocol specification. It returns several other useful
+        /// values also (even though they can be obtained using GetBlock).
+        /// The block can be specified by either height or hash.
+        async fn get_tree_state(
+            &self,
+            request: tonic::Request<super::BlockId>,
+        ) -> std::result::Result<tonic::Response<super::TreeState>, tonic::Status>;
+        async fn get_latest_tree_state(
+            &self,
+            request: tonic::Request<super::Empty>,
+        ) -> std::result::Result<tonic::Response<super::TreeState>, tonic::Status>;
+        /// Server streaming response type for the GetSubtreeRoots method.
+        type GetSubtreeRootsStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::SubtreeRoot, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        /// Returns a stream of information about roots of subtrees of the Sapling and Orchard
+        /// note commitment trees.
+        async fn get_subtree_roots(
+            &self,
+            request: tonic::Request<super::GetSubtreeRootsArg>,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetSubtreeRootsStream>,
+            tonic::Status,
+        >;
+        async fn get_address_utxos(
+            &self,
+            request: tonic::Request<super::GetAddressUtxosArg>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetAddressUtxosReplyList>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the GetAddressUtxosStream method.
+        type GetAddressUtxosStreamStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::GetAddressUtxosReply, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        async fn get_address_utxos_stream(
+            &self,
+            request: tonic::Request<super::GetAddressUtxosArg>,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetAddressUtxosStreamStream>,
+            tonic::Status,
+        >;
+        /// Return information about this lightwalletd instance and the blockchain
+        async fn get_lightd_info(
+            &self,
+            request: tonic::Request<super::Empty>,
+        ) -> std::result::Result<tonic::Response<super::LightdInfo>, tonic::Status>;
+        /// Testing-only, requires lightwalletd --ping-very-insecure (do not enable in production)
+        async fn ping(
+            &self,
+            request: tonic::Request<super::Duration>,
+        ) -> std::result::Result<tonic::Response<super::PingResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct CompactTxStreamerServer<T: CompactTxStreamer> {
+        inner: Arc<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    impl<T: CompactTxStreamer> CompactTxStreamerServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for CompactTxStreamerServer<T>
+    where
+        T: CompactTxStreamer,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetLatestBlockSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::ChainSpec>
+                    for GetLatestBlockSvc<T> {
+                        type Response = super::BlockId;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ChainSpec>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_latest_block(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetLatestBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetBlockSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::BlockId> for GetBlockSvc<T> {
+                        type Response = crate::proto::compact_formats::CompactBlock;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BlockId>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_block(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockNullifiers" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetBlockNullifiersSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::BlockId>
+                    for GetBlockNullifiersSvc<T> {
+                        type Response = crate::proto::compact_formats::CompactBlock;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BlockId>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_block_nullifiers(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetBlockNullifiersSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetBlockRangeSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::BlockRange>
+                    for GetBlockRangeSvc<T> {
+                        type Response = crate::proto::compact_formats::CompactBlock;
+                        type ResponseStream = T::GetBlockRangeStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BlockRange>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_block_range(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetBlockRangeSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRangeNullifiers" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetBlockRangeNullifiersSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::BlockRange>
+                    for GetBlockRangeNullifiersSvc<T> {
+                        type Response = crate::proto::compact_formats::CompactBlock;
+                        type ResponseStream = T::GetBlockRangeNullifiersStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BlockRange>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_block_range_nullifiers(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetBlockRangeNullifiersSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTransaction" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetTransactionSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::TxFilter>
+                    for GetTransactionSvc<T> {
+                        type Response = super::RawTransaction;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::TxFilter>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_transaction(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetTransactionSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/SendTransaction" => {
+                    #[allow(non_camel_case_types)]
+                    struct SendTransactionSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::RawTransaction>
+                    for SendTransactionSvc<T> {
+                        type Response = super::SendResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RawTransaction>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::send_transaction(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SendTransactionSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetTaddressTxidsSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<
+                        super::TransparentAddressBlockFilter,
+                    > for GetTaddressTxidsSvc<T> {
+                        type Response = super::RawTransaction;
+                        type ResponseStream = T::GetTaddressTxidsStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::TransparentAddressBlockFilter>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_taddress_txids(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetTaddressTxidsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalance" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetTaddressBalanceSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::AddressList>
+                    for GetTaddressBalanceSvc<T> {
+                        type Response = super::Balance;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::AddressList>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_taddress_balance(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetTaddressBalanceSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalanceStream" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetTaddressBalanceStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ClientStreamingService<super::Address>
+                    for GetTaddressBalanceStreamSvc<T> {
+                        type Response = super::Balance;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<tonic::Streaming<super::Address>>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_taddress_balance_stream(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetTaddressBalanceStreamSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.client_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolTx" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetMempoolTxSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::Exclude>
+                    for GetMempoolTxSvc<T> {
+                        type Response = crate::proto::compact_formats::CompactTx;
+                        type ResponseStream = T::GetMempoolTxStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Exclude>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_mempool_tx(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetMempoolTxSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolStream" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetMempoolStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::Empty>
+                    for GetMempoolStreamSvc<T> {
+                        type Response = super::RawTransaction;
+                        type ResponseStream = T::GetMempoolStreamStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_mempool_stream(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetMempoolStreamSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTreeState" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetTreeStateSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::BlockId>
+                    for GetTreeStateSvc<T> {
+                        type Response = super::TreeState;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BlockId>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_tree_state(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetTreeStateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestTreeState" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetLatestTreeStateSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty>
+                    for GetLatestTreeStateSvc<T> {
+                        type Response = super::TreeState;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_latest_tree_state(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetLatestTreeStateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetSubtreeRoots" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSubtreeRootsSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::GetSubtreeRootsArg>
+                    for GetSubtreeRootsSvc<T> {
+                        type Response = super::SubtreeRoot;
+                        type ResponseStream = T::GetSubtreeRootsStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetSubtreeRootsArg>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_subtree_roots(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetSubtreeRootsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxos" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetAddressUtxosSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::GetAddressUtxosArg>
+                    for GetAddressUtxosSvc<T> {
+                        type Response = super::GetAddressUtxosReplyList;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetAddressUtxosArg>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_address_utxos(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetAddressUtxosSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxosStream" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetAddressUtxosStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::GetAddressUtxosArg>
+                    for GetAddressUtxosStreamSvc<T> {
+                        type Response = super::GetAddressUtxosReply;
+                        type ResponseStream = T::GetAddressUtxosStreamStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetAddressUtxosArg>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_address_utxos_stream(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetAddressUtxosStreamSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLightdInfo" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetLightdInfoSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty>
+                    for GetLightdInfoSvc<T> {
+                        type Response = super::LightdInfo;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::get_lightd_info(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetLightdInfoSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cash.z.wallet.sdk.rpc.CompactTxStreamer/Ping" => {
+                    #[allow(non_camel_case_types)]
+                    struct PingSvc<T: CompactTxStreamer>(pub Arc<T>);
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::Duration> for PingSvc<T> {
+                        type Response = super::PingResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Duration>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CompactTxStreamer>::ping(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = PingSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", tonic::Code::Unimplemented as i32)
+                                .header(
+                                    http::header::CONTENT_TYPE,
+                                    tonic::metadata::GRPC_CONTENT_TYPE,
+                                )
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: CompactTxStreamer> Clone for CompactTxStreamerServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: CompactTxStreamer> tonic::server::NamedService
+    for CompactTxStreamerServer<T> {
+        const NAME: &'static str = "cash.z.wallet.sdk.rpc.CompactTxStreamer";
+    }
+}

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -1,6 +1,8 @@
 //! Structs representing transaction data scanned from the block chain by a wallet or
 //! light client.
 
+use std::fmt;
+
 use incrementalmerkletree::Position;
 use zcash_address::ZcashAddress;
 use zcash_note_encryption::EphemeralKeyBytes;
@@ -62,6 +64,17 @@ impl NoteId {
     }
 }
 
+impl fmt::Display for NoteId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "txid {} protocol {:?} output_index {}",
+            self.txid(),
+            self.protocol(),
+            self.output_index()
+        )
+    }
+}
 /// A type that represents the recipient of a transaction output:
 /// * a recipient address;
 /// * for external unified addresses, the pool to which the payment is sent;

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -7,56 +7,18 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
-### Added
-- Exposed `AccountId::from_u32` and `AccountId::as_u32` conversions under the
-  `unstable` feature flag.
-
-### Changed
-- MSRV is now 1.77.0.
-- Migrated from `schemer` to our fork `schemerz`.
-- Migrated to `rusqlite 0.32`.
-
-## [0.12.2] - 2024-10-21
-
-### Fixed
-- Fixes an error in determining the minimum checkpoint height to which it's
-  possible to rewind in the case of a reorg, when no other truncation height
-  information is available.
-
-## [0.12.1] - 2024-10-10
-
-### Fixed
-- An error in scan progress computation was fixed. As part of this fix, wallet
-  summary information is now only returned in the case that some note
-  commitment tree size information can be determined, either from subtree root
-  download or from downloaded block data. NOTE: The recovery progress ratio may
-  be present as `0:0` in the case that the recovery range contains no notes; 
-  this was not adequately documented in the previous release.
-
-## [0.12.0] - 2024-10-04
-
-### Added
-- `impl WalletTest for WalletDb` is now available under the `test-dependencies`
-  feature flag.
-
-### Changed
-- Migrated to `zcash_client_backend 0.14`, `orchard 0.10`,
-  `sapling-crypto 0.3`, `shardtree 0.5`, `zcash_address 0.6`,
-  `zcash_primitives 0.19`, `zcash_proofs 0.19`, `zcash_protocol 0.4`.
-- `zcash_client_sqlite::error::SqliteClientError::RequestedRewindInvalid`
-  is now a structured variant.
-
 ## [0.11.2] - 2024-08-21
 
 ### Changed
 - The `v_tx_outputs` view was modified slightly to support older versions of
   `sqlite`. Queries to the exposed `v_tx_outputs` and `v_transactions` views
-  are supported for SQLite versions back to `3.19.x`.
+  are supported for SQLite versions back to `3.19.x`. 
 - `zcash_client_sqlite::wallet::init::WalletMigrationError` has an additional
   variant, `DatabaseNotSupported`. The `init_wallet_db` function now checks
   that the sqlite version in use is compatible with the features required by
   the wallet and returns this error if not. SQLite version `3.35` or higher
   is required for use with `zcash_client_sqlite`.
+
 
 ## [0.11.1] - 2024-08-21
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.12.2"
+version = "0.11.2"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -24,6 +24,1915 @@ use {
 pub(crate) mod db;
 pub(crate) mod pool;
 
+pub(crate) struct InitialChainState {
+    pub(crate) chain_state: ChainState,
+    pub(crate) prior_sapling_roots: Vec<CommitmentTreeRoot<sapling::Node>>,
+    #[cfg(feature = "orchard")]
+    pub(crate) prior_orchard_roots: Vec<CommitmentTreeRoot<MerkleHashOrchard>>,
+}
+
+/// A builder for a `zcash_client_sqlite` test.
+pub(crate) struct TestBuilder<Cache> {
+    rng: ChaChaRng,
+    network: LocalNetwork,
+    cache: Cache,
+    initial_chain_state: Option<InitialChainState>,
+    account_birthday: Option<AccountBirthday>,
+    account_index: Option<zip32::AccountId>,
+}
+
+impl TestBuilder<()> {
+    pub const DEFAULT_NETWORK: LocalNetwork = LocalNetwork {
+        overwinter: Some(BlockHeight::from_u32(1)),
+        sapling: Some(BlockHeight::from_u32(100_000)),
+        blossom: Some(BlockHeight::from_u32(100_000)),
+        heartwood: Some(BlockHeight::from_u32(100_000)),
+        canopy: Some(BlockHeight::from_u32(100_000)),
+        nu5: Some(BlockHeight::from_u32(100_000)),
+        nu6: None,
+        #[cfg(zcash_unstable = "zfuture")]
+        z_future: None,
+    };
+
+    /// Constructs a new test.
+    pub(crate) fn new() -> Self {
+        TestBuilder {
+            rng: ChaChaRng::seed_from_u64(0),
+            // Use a fake network where Sapling through NU5 activate at the same height.
+            // We pick 100,000 to be large enough to handle any hard-coded test offsets.
+            network: Self::DEFAULT_NETWORK,
+            cache: (),
+            initial_chain_state: None,
+            account_birthday: None,
+            account_index: None,
+        }
+    }
+
+    /// Adds a [`BlockDb`] cache to the test.
+    pub(crate) fn with_block_cache(self) -> TestBuilder<BlockCache> {
+        TestBuilder {
+            rng: self.rng,
+            network: self.network,
+            cache: BlockCache::new(),
+            initial_chain_state: self.initial_chain_state,
+            account_birthday: self.account_birthday,
+            account_index: self.account_index,
+        }
+    }
+
+    /// Adds a [`FsBlockDb`] cache to the test.
+    #[cfg(feature = "unstable")]
+    pub(crate) fn with_fs_block_cache(self) -> TestBuilder<FsBlockCache> {
+        TestBuilder {
+            rng: self.rng,
+            network: self.network,
+            cache: FsBlockCache::new(),
+            initial_chain_state: self.initial_chain_state,
+            account_birthday: self.account_birthday,
+            account_index: self.account_index,
+        }
+    }
+}
+
+impl<Cache> TestBuilder<Cache> {
+    pub(crate) fn with_initial_chain_state(
+        mut self,
+        chain_state: impl FnOnce(&mut ChaChaRng, &LocalNetwork) -> InitialChainState,
+    ) -> Self {
+        assert!(self.initial_chain_state.is_none());
+        assert!(self.account_birthday.is_none());
+        self.initial_chain_state = Some(chain_state(&mut self.rng, &self.network));
+        self
+    }
+
+    pub(crate) fn with_account_from_sapling_activation(mut self, prev_hash: BlockHash) -> Self {
+        assert!(self.account_birthday.is_none());
+        self.account_birthday = Some(AccountBirthday::from_parts(
+            ChainState::empty(
+                self.network
+                    .activation_height(NetworkUpgrade::Sapling)
+                    .unwrap()
+                    - 1,
+                prev_hash,
+            ),
+            None,
+        ));
+        self
+    }
+
+    pub(crate) fn with_account_having_current_birthday(mut self) -> Self {
+        assert!(self.account_birthday.is_none());
+        assert!(self.initial_chain_state.is_some());
+        self.account_birthday = Some(AccountBirthday::from_parts(
+            self.initial_chain_state
+                .as_ref()
+                .unwrap()
+                .chain_state
+                .clone(),
+            None,
+        ));
+        self
+    }
+
+    /// Sets the [`account_index`] field for the test account
+    ///
+    /// Call either [`with_account_from_sapling_activation`] or [`with_account_having_current_birthday`] before calling this method.
+    pub(crate) fn set_account_index(mut self, index: zip32::AccountId) -> Self {
+        assert!(self.account_index.is_none());
+        self.account_index = Some(index);
+        self
+    }
+
+    /// Builds the state for this test.
+    pub(crate) fn build(self) -> TestState<Cache> {
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(data_file.path(), self.network).unwrap();
+        init_wallet_db(&mut db_data, None).unwrap();
+
+        let mut cached_blocks = BTreeMap::new();
+
+        if let Some(initial_state) = &self.initial_chain_state {
+            db_data
+                .put_sapling_subtree_roots(0, &initial_state.prior_sapling_roots)
+                .unwrap();
+            db_data
+                .with_sapling_tree_mut(|t| {
+                    t.insert_frontier(
+                        initial_state.chain_state.final_sapling_tree().clone(),
+                        Retention::Checkpoint {
+                            id: initial_state.chain_state.block_height(),
+                            marking: Marking::Reference,
+                        },
+                    )
+                })
+                .unwrap();
+
+            #[cfg(feature = "orchard")]
+            {
+                db_data
+                    .put_orchard_subtree_roots(0, &initial_state.prior_orchard_roots)
+                    .unwrap();
+                db_data
+                    .with_orchard_tree_mut(|t| {
+                        t.insert_frontier(
+                            initial_state.chain_state.final_orchard_tree().clone(),
+                            Retention::Checkpoint {
+                                id: initial_state.chain_state.block_height(),
+                                marking: Marking::Reference,
+                            },
+                        )
+                    })
+                    .unwrap();
+            }
+
+            let final_sapling_tree_size =
+                initial_state.chain_state.final_sapling_tree().tree_size() as u32;
+            let _final_orchard_tree_size = 0;
+            #[cfg(feature = "orchard")]
+            let _final_orchard_tree_size =
+                initial_state.chain_state.final_orchard_tree().tree_size() as u32;
+
+            cached_blocks.insert(
+                initial_state.chain_state.block_height(),
+                CachedBlock {
+                    chain_state: initial_state.chain_state.clone(),
+                    sapling_end_size: final_sapling_tree_size,
+                    orchard_end_size: _final_orchard_tree_size,
+                },
+            );
+        };
+
+        let test_account = self.account_birthday.map(|birthday| {
+            let seed = Secret::new(vec![0u8; 32]);
+            let (account, usk) = match self.account_index {
+                Some(index) => db_data.import_account_hd(&seed, index, &birthday).unwrap(),
+                None => {
+                    let result = db_data.create_account(&seed, &birthday).unwrap();
+                    (db_data.get_account(result.0).unwrap().unwrap(), result.1)
+                }
+            };
+            (
+                seed,
+                TestAccount {
+                    account,
+                    usk,
+                    birthday,
+                },
+            )
+        });
+
+        TestState {
+            cache: self.cache,
+            cached_blocks,
+            latest_block_height: self
+                .initial_chain_state
+                .map(|s| s.chain_state.block_height()),
+            _data_file: data_file,
+            db_data,
+            test_account,
+            rng: self.rng,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CachedBlock {
+    chain_state: ChainState,
+    sapling_end_size: u32,
+    orchard_end_size: u32,
+}
+
+impl CachedBlock {
+    fn none(sapling_activation_height: BlockHeight) -> Self {
+        Self {
+            chain_state: ChainState::empty(sapling_activation_height, BlockHash([0; 32])),
+            sapling_end_size: 0,
+            orchard_end_size: 0,
+        }
+    }
+
+    fn at(chain_state: ChainState, sapling_end_size: u32, orchard_end_size: u32) -> Self {
+        assert_eq!(
+            chain_state.final_sapling_tree().tree_size() as u32,
+            sapling_end_size
+        );
+        #[cfg(feature = "orchard")]
+        assert_eq!(
+            chain_state.final_orchard_tree().tree_size() as u32,
+            orchard_end_size
+        );
+
+        Self {
+            chain_state,
+            sapling_end_size,
+            orchard_end_size,
+        }
+    }
+
+    fn roll_forward(&self, cb: &CompactBlock) -> Self {
+        assert_eq!(self.chain_state.block_height() + 1, cb.height());
+
+        let sapling_final_tree = cb.vtx.iter().flat_map(|tx| tx.outputs.iter()).fold(
+            self.chain_state.final_sapling_tree().clone(),
+            |mut acc, c_out| {
+                acc.append(sapling::Node::from_cmu(&c_out.cmu().unwrap()));
+                acc
+            },
+        );
+        let sapling_end_size = sapling_final_tree.tree_size() as u32;
+
+        #[cfg(feature = "orchard")]
+        let orchard_final_tree = cb.vtx.iter().flat_map(|tx| tx.actions.iter()).fold(
+            self.chain_state.final_orchard_tree().clone(),
+            |mut acc, c_act| {
+                acc.append(MerkleHashOrchard::from_cmx(&c_act.cmx().unwrap()));
+                acc
+            },
+        );
+        #[cfg(feature = "orchard")]
+        let orchard_end_size = orchard_final_tree.tree_size() as u32;
+        #[cfg(not(feature = "orchard"))]
+        let orchard_end_size = cb.vtx.iter().fold(self.orchard_end_size, |sz, tx| {
+            sz + (tx.actions.len() as u32)
+        });
+
+        Self {
+            chain_state: ChainState::new(
+                cb.height(),
+                cb.hash(),
+                sapling_final_tree,
+                #[cfg(feature = "orchard")]
+                orchard_final_tree,
+            ),
+            sapling_end_size,
+            orchard_end_size,
+        }
+    }
+
+    fn height(&self) -> BlockHeight {
+        self.chain_state.block_height()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TestAccount {
+    account: Account,
+    usk: UnifiedSpendingKey,
+    birthday: AccountBirthday,
+}
+
+impl TestAccount {
+    pub(crate) fn account(&self) -> &Account {
+        &self.account
+    }
+
+    pub(crate) fn account_id(&self) -> AccountId {
+        self.account.id()
+    }
+
+    pub(crate) fn usk(&self) -> &UnifiedSpendingKey {
+        &self.usk
+    }
+
+    pub(crate) fn birthday(&self) -> &AccountBirthday {
+        &self.birthday
+    }
+}
+
+/// The state for a `zcash_client_sqlite` test.
+pub(crate) struct TestState<Cache> {
+    cache: Cache,
+    cached_blocks: BTreeMap<BlockHeight, CachedBlock>,
+    latest_block_height: Option<BlockHeight>,
+    _data_file: NamedTempFile,
+    db_data: WalletDb<Connection, LocalNetwork>,
+    test_account: Option<(SecretVec<u8>, TestAccount)>,
+    rng: ChaChaRng,
+}
+
+impl<Cache: TestCache> TestState<Cache>
+where
+    <Cache::BlockSource as BlockSource>::Error: fmt::Debug,
+{
+    /// Exposes an immutable reference to the test's [`BlockSource`].
+    #[cfg(feature = "unstable")]
+    pub(crate) fn cache(&self) -> &Cache::BlockSource {
+        self.cache.block_source()
+    }
+
+    pub(crate) fn latest_cached_block(&self) -> Option<&CachedBlock> {
+        self.latest_block_height
+            .as_ref()
+            .and_then(|h| self.cached_blocks.get(h))
+    }
+
+    fn latest_cached_block_below_height(&self, height: BlockHeight) -> Option<&CachedBlock> {
+        self.cached_blocks.range(..height).last().map(|(_, b)| b)
+    }
+
+    fn cache_block(
+        &mut self,
+        prev_block: &CachedBlock,
+        compact_block: CompactBlock,
+    ) -> Cache::InsertResult {
+        self.cached_blocks.insert(
+            compact_block.height(),
+            prev_block.roll_forward(&compact_block),
+        );
+        self.cache.insert(&compact_block)
+    }
+
+    /// Creates a fake block at the expected next height containing a single output of the
+    /// given value, and inserts it into the cache.
+    pub(crate) fn generate_next_block<Fvk: TestFvk>(
+        &mut self,
+        fvk: &Fvk,
+        address_type: AddressType,
+        value: NonNegativeAmount,
+    ) -> (BlockHeight, Cache::InsertResult, Fvk::Nullifier) {
+        let pre_activation_block = CachedBlock::none(self.sapling_activation_height() - 1);
+        let prior_cached_block = self.latest_cached_block().unwrap_or(&pre_activation_block);
+        let height = prior_cached_block.height() + 1;
+
+        let (res, nfs) = self.generate_block_at(
+            height,
+            prior_cached_block.chain_state.block_hash(),
+            &[FakeCompactOutput::new(fvk, address_type, value)],
+            prior_cached_block.sapling_end_size,
+            prior_cached_block.orchard_end_size,
+            false,
+        );
+
+        (height, res, nfs[0])
+    }
+
+    /// Creates a fake block at the expected next height containing multiple outputs
+    /// and inserts it into the cache.
+    #[allow(dead_code)]
+    pub(crate) fn generate_next_block_multi<Fvk: TestFvk>(
+        &mut self,
+        outputs: &[FakeCompactOutput<Fvk>],
+    ) -> (BlockHeight, Cache::InsertResult, Vec<Fvk::Nullifier>) {
+        let pre_activation_block = CachedBlock::none(self.sapling_activation_height() - 1);
+        let prior_cached_block = self.latest_cached_block().unwrap_or(&pre_activation_block);
+        let height = prior_cached_block.height() + 1;
+
+        let (res, nfs) = self.generate_block_at(
+            height,
+            prior_cached_block.chain_state.block_hash(),
+            outputs,
+            prior_cached_block.sapling_end_size,
+            prior_cached_block.orchard_end_size,
+            false,
+        );
+
+        (height, res, nfs)
+    }
+
+    /// Adds an empty block to the cache, advancing the simulated chain height.
+    #[allow(dead_code)] // used only for tests that are flagged off by default
+    pub(crate) fn generate_empty_block(&mut self) -> (BlockHeight, Cache::InsertResult) {
+        let new_hash = {
+            let mut hash = vec![0; 32];
+            self.rng.fill_bytes(&mut hash);
+            hash
+        };
+
+        let pre_activation_block = CachedBlock::none(self.sapling_activation_height() - 1);
+        let prior_cached_block = self
+            .latest_cached_block()
+            .unwrap_or(&pre_activation_block)
+            .clone();
+        let new_height = prior_cached_block.height() + 1;
+
+        let mut cb = CompactBlock {
+            hash: new_hash,
+            height: new_height.into(),
+            ..Default::default()
+        };
+        cb.prev_hash
+            .extend_from_slice(&prior_cached_block.chain_state.block_hash().0);
+
+        cb.chain_metadata = Some(compact::ChainMetadata {
+            sapling_commitment_tree_size: prior_cached_block.sapling_end_size,
+            orchard_commitment_tree_size: prior_cached_block.orchard_end_size,
+        });
+
+        let res = self.cache_block(&prior_cached_block, cb);
+        self.latest_block_height = Some(new_height);
+
+        (new_height, res)
+    }
+
+    /// Creates a fake block with the given height and hash containing the requested outputs, and
+    /// inserts it into the cache.
+    ///
+    /// This generated block will be treated as the latest block, and subsequent calls to
+    /// [`Self::generate_next_block`] will build on it.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn generate_block_at<Fvk: TestFvk>(
+        &mut self,
+        height: BlockHeight,
+        prev_hash: BlockHash,
+        outputs: &[FakeCompactOutput<Fvk>],
+        initial_sapling_tree_size: u32,
+        initial_orchard_tree_size: u32,
+        allow_broken_hash_chain: bool,
+    ) -> (Cache::InsertResult, Vec<Fvk::Nullifier>) {
+        let mut prior_cached_block = self
+            .latest_cached_block_below_height(height)
+            .cloned()
+            .unwrap_or_else(|| CachedBlock::none(self.sapling_activation_height() - 1));
+        assert!(prior_cached_block.chain_state.block_height() < height);
+        assert!(prior_cached_block.sapling_end_size <= initial_sapling_tree_size);
+        assert!(prior_cached_block.orchard_end_size <= initial_orchard_tree_size);
+
+        // If the block height has increased or the Sapling and/or Orchard tree sizes have changed,
+        // we need to generate a new prior cached block that the block to be generated can
+        // successfully chain from, with the provided tree sizes.
+        if prior_cached_block.chain_state.block_height() == height - 1 {
+            if !allow_broken_hash_chain {
+                assert_eq!(prev_hash, prior_cached_block.chain_state.block_hash());
+            }
+        } else {
+            let final_sapling_tree =
+                (prior_cached_block.sapling_end_size..initial_sapling_tree_size).fold(
+                    prior_cached_block.chain_state.final_sapling_tree().clone(),
+                    |mut acc, _| {
+                        acc.append(sapling::Node::from_scalar(bls12_381::Scalar::random(
+                            &mut self.rng,
+                        )));
+                        acc
+                    },
+                );
+
+            #[cfg(feature = "orchard")]
+            let final_orchard_tree =
+                (prior_cached_block.orchard_end_size..initial_orchard_tree_size).fold(
+                    prior_cached_block.chain_state.final_orchard_tree().clone(),
+                    |mut acc, _| {
+                        acc.append(MerkleHashOrchard::random(&mut self.rng));
+                        acc
+                    },
+                );
+
+            prior_cached_block = CachedBlock::at(
+                ChainState::new(
+                    height - 1,
+                    prev_hash,
+                    final_sapling_tree,
+                    #[cfg(feature = "orchard")]
+                    final_orchard_tree,
+                ),
+                initial_sapling_tree_size,
+                initial_orchard_tree_size,
+            );
+
+            self.cached_blocks
+                .insert(height - 1, prior_cached_block.clone());
+        }
+
+        let (cb, nfs) = fake_compact_block(
+            &self.network(),
+            height,
+            prev_hash,
+            outputs,
+            initial_sapling_tree_size,
+            initial_orchard_tree_size,
+            &mut self.rng,
+        );
+        assert_eq!(cb.height(), height);
+
+        let res = self.cache_block(&prior_cached_block, cb);
+        self.latest_block_height = Some(height);
+
+        (res, nfs)
+    }
+
+    /// Creates a fake block at the expected next height spending the given note, and
+    /// inserts it into the cache.
+    pub(crate) fn generate_next_block_spending<Fvk: TestFvk>(
+        &mut self,
+        fvk: &Fvk,
+        note: (Fvk::Nullifier, NonNegativeAmount),
+        to: impl Into<Address>,
+        value: NonNegativeAmount,
+    ) -> (BlockHeight, Cache::InsertResult) {
+        let prior_cached_block = self
+            .latest_cached_block()
+            .cloned()
+            .unwrap_or_else(|| CachedBlock::none(self.sapling_activation_height() - 1));
+        let height = prior_cached_block.height() + 1;
+
+        let cb = fake_compact_block_spending(
+            &self.network(),
+            height,
+            prior_cached_block.chain_state.block_hash(),
+            note,
+            fvk,
+            to.into(),
+            value,
+            prior_cached_block.sapling_end_size,
+            prior_cached_block.orchard_end_size,
+            &mut self.rng,
+        );
+        assert_eq!(cb.height(), height);
+
+        let res = self.cache_block(&prior_cached_block, cb);
+        self.latest_block_height = Some(height);
+
+        (height, res)
+    }
+
+    /// Creates a fake block at the expected next height containing only the wallet
+    /// transaction with the given txid, and inserts it into the cache.
+    ///
+    /// This generated block will be treated as the latest block, and subsequent calls to
+    /// [`Self::generate_next_block`] (or similar) will build on it.
+    pub(crate) fn generate_next_block_including(
+        &mut self,
+        txid: TxId,
+    ) -> (BlockHeight, Cache::InsertResult) {
+        let tx = self
+            .wallet()
+            .get_transaction(txid)
+            .unwrap()
+            .expect("TxId should exist in the wallet");
+
+        // Index 0 is by definition a coinbase transaction, and the wallet doesn't
+        // construct coinbase transactions. So we pretend here that the block has a
+        // coinbase transaction that does not have shielded coinbase outputs.
+        self.generate_next_block_from_tx(1, &tx)
+    }
+
+    /// Creates a fake block at the expected next height containing only the given
+    /// transaction, and inserts it into the cache.
+    ///
+    /// This generated block will be treated as the latest block, and subsequent calls to
+    /// [`Self::generate_next_block`] will build on it.
+    pub(crate) fn generate_next_block_from_tx(
+        &mut self,
+        tx_index: usize,
+        tx: &Transaction,
+    ) -> (BlockHeight, Cache::InsertResult) {
+        let prior_cached_block = self
+            .latest_cached_block()
+            .cloned()
+            .unwrap_or_else(|| CachedBlock::none(self.sapling_activation_height() - 1));
+        let height = prior_cached_block.height() + 1;
+
+        let cb = fake_compact_block_from_tx(
+            height,
+            prior_cached_block.chain_state.block_hash(),
+            tx_index,
+            tx,
+            prior_cached_block.sapling_end_size,
+            prior_cached_block.orchard_end_size,
+            &mut self.rng,
+        );
+        assert_eq!(cb.height(), height);
+
+        let res = self.cache_block(&prior_cached_block, cb);
+        self.latest_block_height = Some(height);
+
+        (height, res)
+    }
+
+    /// Invokes [`scan_cached_blocks`] with the given arguments, expecting success.
+    pub(crate) fn scan_cached_blocks(
+        &mut self,
+        from_height: BlockHeight,
+        limit: usize,
+    ) -> ScanSummary {
+        let result = self.try_scan_cached_blocks(from_height, limit);
+        assert_matches!(result, Ok(_));
+        result.unwrap()
+    }
+
+    /// Invokes [`scan_cached_blocks`] with the given arguments.
+    pub(crate) fn try_scan_cached_blocks(
+        &mut self,
+        from_height: BlockHeight,
+        limit: usize,
+    ) -> Result<
+        ScanSummary,
+        data_api::chain::error::Error<
+            SqliteClientError,
+            <Cache::BlockSource as BlockSource>::Error,
+        >,
+    > {
+        let prior_cached_block = self
+            .latest_cached_block_below_height(from_height)
+            .cloned()
+            .unwrap_or_else(|| CachedBlock::none(from_height - 1));
+
+        let result = scan_cached_blocks(
+            &self.network(),
+            self.cache.block_source(),
+            &mut self.db_data,
+            from_height,
+            &prior_cached_block.chain_state,
+            limit,
+        );
+        result
+    }
+
+    /// Resets the wallet using a new wallet database but with the same cache of blocks,
+    /// and returns the old wallet database file.
+    ///
+    /// This does not recreate accounts, nor does it rescan the cached blocks.
+    /// The resulting wallet has no test account.
+    /// Before using any `generate_*` method on the reset state, call `reset_latest_cached_block()`.
+    pub(crate) fn reset(&mut self) -> NamedTempFile {
+        let network = self.network();
+        self.latest_block_height = None;
+        let tf = std::mem::replace(&mut self._data_file, NamedTempFile::new().unwrap());
+        self.db_data = WalletDb::for_path(self._data_file.path(), network).unwrap();
+        self.test_account = None;
+        init_wallet_db(&mut self.db_data, None).unwrap();
+        tf
+    }
+
+    //    /// Reset the latest cached block to the most recent one in the cache database.
+    //    #[allow(dead_code)]
+    //    pub(crate) fn reset_latest_cached_block(&mut self) {
+    //        self.cache
+    //            .block_source()
+    //            .with_blocks::<_, Infallible>(None, None, |block: CompactBlock| {
+    //                let chain_metadata = block.chain_metadata.unwrap();
+    //                self.latest_cached_block = Some(CachedBlock::at(
+    //                    BlockHash::from_slice(block.hash.as_slice()),
+    //                    BlockHeight::from_u32(block.height.try_into().unwrap()),
+    //                    chain_metadata.sapling_commitment_tree_size,
+    //                    chain_metadata.orchard_commitment_tree_size,
+    //                ));
+    //                Ok(())
+    //            })
+    //            .unwrap();
+    //    }
+}
+
+impl<Cache> TestState<Cache> {
+    /// Exposes an immutable reference to the test's [`WalletDb`].
+    pub(crate) fn wallet(&self) -> &WalletDb<Connection, LocalNetwork> {
+        &self.db_data
+    }
+
+    /// Exposes a mutable reference to the test's [`WalletDb`].
+    pub(crate) fn wallet_mut(&mut self) -> &mut WalletDb<Connection, LocalNetwork> {
+        &mut self.db_data
+    }
+
+    /// Exposes the test framework's source of randomness.
+    pub(crate) fn rng_mut(&mut self) -> &mut ChaChaRng {
+        &mut self.rng
+    }
+
+    /// Exposes the network in use.
+    pub(crate) fn network(&self) -> LocalNetwork {
+        self.db_data.params
+    }
+
+    /// Convenience method for obtaining the Sapling activation height for the network under test.
+    pub(crate) fn sapling_activation_height(&self) -> BlockHeight {
+        self.db_data
+            .params
+            .activation_height(NetworkUpgrade::Sapling)
+            .expect("Sapling activation height must be known.")
+    }
+
+    /// Convenience method for obtaining the NU5 activation height for the network under test.
+    #[allow(dead_code)]
+    pub(crate) fn nu5_activation_height(&self) -> BlockHeight {
+        self.db_data
+            .params
+            .activation_height(NetworkUpgrade::Nu5)
+            .expect("NU5 activation height must be known.")
+    }
+
+    /// Exposes the test seed, if enabled via [`TestBuilder::with_test_account`].
+    pub(crate) fn test_seed(&self) -> Option<&SecretVec<u8>> {
+        self.test_account.as_ref().map(|(seed, _)| seed)
+    }
+
+    /// Exposes the test account, if enabled via [`TestBuilder::with_test_account`].
+    pub(crate) fn test_account(&self) -> Option<&TestAccount> {
+        self.test_account.as_ref().map(|(_, acct)| acct)
+    }
+
+    /// Exposes the test account's Sapling DFVK, if enabled via [`TestBuilder::with_test_account`].
+    pub(crate) fn test_account_sapling(&self) -> Option<DiversifiableFullViewingKey> {
+        self.test_account
+            .as_ref()
+            .and_then(|(_, acct)| acct.usk.to_unified_full_viewing_key().sapling().cloned())
+    }
+
+    /// Exposes the test account's Sapling DFVK, if enabled via [`TestBuilder::with_test_account`].
+    #[cfg(feature = "orchard")]
+    pub(crate) fn test_account_orchard(&self) -> Option<orchard::keys::FullViewingKey> {
+        self.test_account
+            .as_ref()
+            .and_then(|(_, acct)| acct.usk.to_unified_full_viewing_key().orchard().cloned())
+    }
+
+    /// Insert shard roots for both trees.
+    pub(crate) fn put_subtree_roots(
+        &mut self,
+        sapling_start_index: u64,
+        sapling_roots: &[CommitmentTreeRoot<sapling::Node>],
+        #[cfg(feature = "orchard")] orchard_start_index: u64,
+        #[cfg(feature = "orchard")] orchard_roots: &[CommitmentTreeRoot<MerkleHashOrchard>],
+    ) -> Result<(), ShardTreeError<commitment_tree::Error>> {
+        self.wallet_mut()
+            .put_sapling_subtree_roots(sapling_start_index, sapling_roots)?;
+
+        #[cfg(feature = "orchard")]
+        self.wallet_mut()
+            .put_orchard_subtree_roots(orchard_start_index, orchard_roots)?;
+
+        Ok(())
+    }
+
+    /// Invokes [`create_spend_to_address`] with the given arguments.
+    #[allow(deprecated)]
+    #[allow(clippy::type_complexity)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn create_spend_to_address(
+        &mut self,
+        usk: &UnifiedSpendingKey,
+        to: &Address,
+        amount: NonNegativeAmount,
+        memo: Option<MemoBytes>,
+        ovk_policy: OvkPolicy,
+        min_confirmations: NonZeroU32,
+        change_memo: Option<MemoBytes>,
+        fallback_change_pool: ShieldedProtocol,
+    ) -> Result<
+        NonEmpty<TxId>,
+        data_api::error::Error<
+            SqliteClientError,
+            commitment_tree::Error,
+            GreedyInputSelectorError<Zip317FeeError, ReceivedNoteId>,
+            Zip317FeeError,
+        >,
+    > {
+        let params = self.network();
+        let prover = test_prover();
+        create_spend_to_address(
+            &mut self.db_data,
+            &params,
+            &prover,
+            &prover,
+            usk,
+            to,
+            amount,
+            memo,
+            ovk_policy,
+            min_confirmations,
+            change_memo,
+            fallback_change_pool,
+        )
+    }
+
+    /// Invokes [`spend`] with the given arguments.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn spend<InputsT>(
+        &mut self,
+        input_selector: &InputsT,
+        usk: &UnifiedSpendingKey,
+        request: zip321::TransactionRequest,
+        ovk_policy: OvkPolicy,
+        min_confirmations: NonZeroU32,
+    ) -> Result<
+        NonEmpty<TxId>,
+        data_api::error::Error<
+            SqliteClientError,
+            commitment_tree::Error,
+            InputsT::Error,
+            <InputsT::FeeRule as FeeRule>::Error,
+        >,
+    >
+    where
+        InputsT: InputSelector<InputSource = WalletDb<Connection, LocalNetwork>>,
+    {
+        #![allow(deprecated)]
+        let params = self.network();
+        let prover = test_prover();
+        spend(
+            &mut self.db_data,
+            &params,
+            &prover,
+            &prover,
+            input_selector,
+            usk,
+            request,
+            ovk_policy,
+            min_confirmations,
+        )
+    }
+
+    /// Invokes [`propose_transfer`] with the given arguments.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn propose_transfer<InputsT>(
+        &mut self,
+        spend_from_account: AccountId,
+        input_selector: &InputsT,
+        request: zip321::TransactionRequest,
+        min_confirmations: NonZeroU32,
+    ) -> Result<
+        Proposal<InputsT::FeeRule, ReceivedNoteId>,
+        data_api::error::Error<
+            SqliteClientError,
+            Infallible,
+            InputsT::Error,
+            <InputsT::FeeRule as FeeRule>::Error,
+        >,
+    >
+    where
+        InputsT: InputSelector<InputSource = WalletDb<Connection, LocalNetwork>>,
+    {
+        let params = self.network();
+        propose_transfer::<_, _, _, Infallible>(
+            &mut self.db_data,
+            &params,
+            spend_from_account,
+            input_selector,
+            request,
+            min_confirmations,
+        )
+    }
+
+    /// Invokes [`propose_standard_transfer`] with the given arguments.
+    #[allow(clippy::type_complexity)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn propose_standard_transfer<CommitmentTreeErrT>(
+        &mut self,
+        spend_from_account: AccountId,
+        fee_rule: StandardFeeRule,
+        min_confirmations: NonZeroU32,
+        to: &Address,
+        amount: NonNegativeAmount,
+        memo: Option<MemoBytes>,
+        change_memo: Option<MemoBytes>,
+        fallback_change_pool: ShieldedProtocol,
+    ) -> Result<
+        Proposal<StandardFeeRule, ReceivedNoteId>,
+        data_api::error::Error<
+            SqliteClientError,
+            CommitmentTreeErrT,
+            GreedyInputSelectorError<Zip317FeeError, ReceivedNoteId>,
+            Zip317FeeError,
+        >,
+    > {
+        let params = self.network();
+        let result = propose_standard_transfer_to_address::<_, _, CommitmentTreeErrT>(
+            &mut self.db_data,
+            &params,
+            fee_rule,
+            spend_from_account,
+            min_confirmations,
+            to,
+            amount,
+            memo,
+            change_memo,
+            fallback_change_pool,
+        );
+
+        if let Ok(proposal) = &result {
+            check_proposal_serialization_roundtrip(self.wallet(), proposal);
+        }
+
+        result
+    }
+
+    /// Invokes [`propose_shielding`] with the given arguments.
+    #[cfg(feature = "transparent-inputs")]
+    #[allow(clippy::type_complexity)]
+    #[allow(dead_code)]
+    pub(crate) fn propose_shielding<InputsT>(
+        &mut self,
+        input_selector: &InputsT,
+        shielding_threshold: NonNegativeAmount,
+        from_addrs: &[TransparentAddress],
+        min_confirmations: u32,
+    ) -> Result<
+        Proposal<InputsT::FeeRule, Infallible>,
+        data_api::error::Error<
+            SqliteClientError,
+            Infallible,
+            InputsT::Error,
+            <InputsT::FeeRule as FeeRule>::Error,
+        >,
+    >
+    where
+        InputsT: ShieldingSelector<InputSource = WalletDb<Connection, LocalNetwork>>,
+    {
+        let params = self.network();
+        propose_shielding::<_, _, _, Infallible>(
+            &mut self.db_data,
+            &params,
+            input_selector,
+            shielding_threshold,
+            from_addrs,
+            min_confirmations,
+        )
+    }
+
+    /// Invokes [`create_proposed_transactions`] with the given arguments.
+    pub(crate) fn create_proposed_transactions<InputsErrT, FeeRuleT>(
+        &mut self,
+        usk: &UnifiedSpendingKey,
+        ovk_policy: OvkPolicy,
+        proposal: &Proposal<FeeRuleT, ReceivedNoteId>,
+    ) -> Result<
+        NonEmpty<TxId>,
+        data_api::error::Error<
+            SqliteClientError,
+            commitment_tree::Error,
+            InputsErrT,
+            FeeRuleT::Error,
+        >,
+    >
+    where
+        FeeRuleT: FeeRule,
+    {
+        let params = self.network();
+        let prover = test_prover();
+        create_proposed_transactions(
+            &mut self.db_data,
+            &params,
+            &prover,
+            &prover,
+            usk,
+            ovk_policy,
+            proposal,
+            None,
+        )
+    }
+
+    /// Invokes [`shield_transparent_funds`] with the given arguments.
+    #[cfg(feature = "transparent-inputs")]
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn shield_transparent_funds<InputsT>(
+        &mut self,
+        input_selector: &InputsT,
+        shielding_threshold: NonNegativeAmount,
+        usk: &UnifiedSpendingKey,
+        from_addrs: &[TransparentAddress],
+        min_confirmations: u32,
+    ) -> Result<
+        NonEmpty<TxId>,
+        data_api::error::Error<
+            SqliteClientError,
+            commitment_tree::Error,
+            InputsT::Error,
+            <InputsT::FeeRule as FeeRule>::Error,
+        >,
+    >
+    where
+        InputsT: ShieldingSelector<InputSource = WalletDb<Connection, LocalNetwork>>,
+    {
+        let params = self.network();
+        let prover = test_prover();
+        shield_transparent_funds(
+            &mut self.db_data,
+            &params,
+            &prover,
+            &prover,
+            input_selector,
+            shielding_threshold,
+            usk,
+            from_addrs,
+            min_confirmations,
+        )
+    }
+
+    fn with_account_balance<T, F: FnOnce(&AccountBalance) -> T>(
+        &self,
+        account: AccountId,
+        min_confirmations: u32,
+        f: F,
+    ) -> T {
+        let binding = self.get_wallet_summary(min_confirmations).unwrap();
+        f(binding.account_balances().get(&account).unwrap())
+    }
+
+    pub(crate) fn get_total_balance(&self, account: AccountId) -> NonNegativeAmount {
+        self.with_account_balance(account, 0, |balance| balance.total())
+    }
+
+    pub(crate) fn get_spendable_balance(
+        &self,
+        account: AccountId,
+        min_confirmations: u32,
+    ) -> NonNegativeAmount {
+        self.with_account_balance(account, min_confirmations, |balance| {
+            balance.spendable_value()
+        })
+    }
+
+    pub(crate) fn get_pending_shielded_balance(
+        &self,
+        account: AccountId,
+        min_confirmations: u32,
+    ) -> NonNegativeAmount {
+        self.with_account_balance(account, min_confirmations, |balance| {
+            balance.value_pending_spendability() + balance.change_pending_confirmation()
+        })
+        .unwrap()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn get_pending_change(
+        &self,
+        account: AccountId,
+        min_confirmations: u32,
+    ) -> NonNegativeAmount {
+        self.with_account_balance(account, min_confirmations, |balance| {
+            balance.change_pending_confirmation()
+        })
+    }
+
+    pub(crate) fn get_wallet_summary(
+        &self,
+        min_confirmations: u32,
+    ) -> Option<WalletSummary<AccountId>> {
+        get_wallet_summary(
+            &self.wallet().conn.unchecked_transaction().unwrap(),
+            &self.wallet().params,
+            min_confirmations,
+            &SubtreeScanProgress,
+        )
+        .unwrap()
+    }
+
+    /// Returns a transaction from the history.
+    #[allow(dead_code)]
+    pub(crate) fn get_tx_from_history(
+        &self,
+        txid: TxId,
+    ) -> Result<Option<TransactionSummary<AccountId>>, SqliteClientError> {
+        let history = self.get_tx_history()?;
+        Ok(history.into_iter().find(|tx| tx.txid() == txid))
+    }
+
+    /// Returns a vector of transaction summaries
+    pub(crate) fn get_tx_history(
+        &self,
+    ) -> Result<Vec<TransactionSummary<AccountId>>, SqliteClientError> {
+        let mut stmt = self.wallet().conn.prepare_cached(
+            "SELECT *
+             FROM v_transactions
+             ORDER BY mined_height DESC, tx_index DESC",
+        )?;
+
+        let results = stmt
+            .query_and_then::<TransactionSummary<AccountId>, SqliteClientError, _, _>([], |row| {
+                Ok(TransactionSummary {
+                    account_id: AccountId(row.get("account_id")?),
+                    txid: TxId::from_bytes(row.get("txid")?),
+                    expiry_height: row
+                        .get::<_, Option<u32>>("expiry_height")?
+                        .map(BlockHeight::from),
+                    mined_height: row
+                        .get::<_, Option<u32>>("mined_height")?
+                        .map(BlockHeight::from),
+                    account_value_delta: ZatBalance::from_i64(row.get("account_balance_delta")?)?,
+                    fee_paid: row
+                        .get::<_, Option<i64>>("fee_paid")?
+                        .map(Zatoshis::from_nonnegative_i64)
+                        .transpose()?,
+                    spent_note_count: row.get("spent_note_count")?,
+                    has_change: row.get("has_change")?,
+                    sent_note_count: row.get("sent_note_count")?,
+                    received_note_count: row.get("received_note_count")?,
+                    memo_count: row.get("memo_count")?,
+                    expired_unmined: row.get("expired_unmined")?,
+                    is_shielding: row.get("is_shielding")?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(results)
+    }
+
+    #[allow(dead_code)] // used only for tests that are flagged off by default
+    pub(crate) fn get_checkpoint_history(
+        &self,
+    ) -> Result<Vec<(BlockHeight, ShieldedProtocol, Option<Position>)>, SqliteClientError> {
+        let mut stmt = self.wallet().conn.prepare_cached(
+            "SELECT checkpoint_id, 2 AS pool, position FROM sapling_tree_checkpoints
+             UNION
+             SELECT checkpoint_id, 3 AS pool, position FROM orchard_tree_checkpoints
+             ORDER BY checkpoint_id",
+        )?;
+
+        let results = stmt
+            .query_and_then::<_, SqliteClientError, _, _>([], |row| {
+                Ok((
+                    BlockHeight::from(row.get::<_, u32>(0)?),
+                    match row.get::<_, i64>(1)? {
+                        2 => ShieldedProtocol::Sapling,
+                        3 => ShieldedProtocol::Orchard,
+                        _ => unreachable!(),
+                    },
+                    row.get::<_, Option<u64>>(2)?.map(Position::from),
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(results)
+    }
+
+    /// Dump the schema and contents of the given database table, in
+    /// sqlite3 ".dump" format. The name of the table must be a static
+    /// string. This assumes that `sqlite3` is on your path and that it
+    /// invokes a compatible version of sqlite3.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` contains characters outside `[a-zA-Z_]`.
+    #[allow(dead_code)]
+    #[cfg(feature = "unstable")]
+    pub(crate) fn dump_table(&self, name: &'static str) {
+        assert!(name.chars().all(|c| c.is_ascii_alphabetic() || c == '_'));
+        unsafe {
+            run_sqlite3(self._data_file.path(), &format!(r#".dump "{name}""#));
+        }
+    }
+
+    /// Print the results of an arbitrary sqlite3 command (with "-safe"
+    /// and "-readonly" flags) to stderr. This is completely insecure and
+    /// should not be exposed in production. Use of the "-safe" and
+    /// "-readonly" flags is intended only to limit *accidental* misuse.
+    /// The output is unfiltered, and control codes could mess up your
+    /// terminal. This assumes that `sqlite3` is on your path and that it
+    /// invokes a compatible version of sqlite3.
+    #[allow(dead_code)]
+    #[cfg(feature = "unstable")]
+    pub(crate) unsafe fn run_sqlite3(&self, command: &str) {
+        run_sqlite3(self._data_file.path(), command)
+    }
+}
+
+// See the doc comment for `TestState::run_sqlite3` above.
+//
+// - `db_path` is the path to the database file.
+// - `command` may contain newlines.
+#[allow(dead_code)]
+#[cfg(feature = "unstable")]
+unsafe fn run_sqlite3<S: AsRef<OsStr>>(db_path: S, command: &str) {
+    use std::process::Command;
+    let output = Command::new("sqlite3")
+        .arg(db_path)
+        .arg("-safe")
+        .arg("-readonly")
+        .arg(command)
+        .output()
+        .expect("failed to execute sqlite3 process");
+
+    eprintln!(
+        "{}\n------\n{}",
+        command,
+        String::from_utf8_lossy(&output.stdout)
+    );
+    if !output.stderr.is_empty() {
+        eprintln!(
+            "------ stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    eprintln!("------");
+}
+
+pub(crate) struct TransactionSummary<AccountId> {
+    account_id: AccountId,
+    txid: TxId,
+    expiry_height: Option<BlockHeight>,
+    mined_height: Option<BlockHeight>,
+    account_value_delta: ZatBalance,
+    fee_paid: Option<Zatoshis>,
+    spent_note_count: usize,
+    has_change: bool,
+    sent_note_count: usize,
+    received_note_count: usize,
+    memo_count: usize,
+    expired_unmined: bool,
+    is_shielding: bool,
+}
+
+#[allow(dead_code)]
+impl<AccountId> TransactionSummary<AccountId> {
+    pub(crate) fn account_id(&self) -> &AccountId {
+        &self.account_id
+    }
+
+    pub(crate) fn txid(&self) -> TxId {
+        self.txid
+    }
+
+    pub(crate) fn expiry_height(&self) -> Option<BlockHeight> {
+        self.expiry_height
+    }
+
+    pub(crate) fn mined_height(&self) -> Option<BlockHeight> {
+        self.mined_height
+    }
+
+    pub(crate) fn account_value_delta(&self) -> ZatBalance {
+        self.account_value_delta
+    }
+
+    pub(crate) fn fee_paid(&self) -> Option<Zatoshis> {
+        self.fee_paid
+    }
+
+    pub(crate) fn spent_note_count(&self) -> usize {
+        self.spent_note_count
+    }
+
+    pub(crate) fn has_change(&self) -> bool {
+        self.has_change
+    }
+
+    pub(crate) fn sent_note_count(&self) -> usize {
+        self.sent_note_count
+    }
+
+    pub(crate) fn received_note_count(&self) -> usize {
+        self.received_note_count
+    }
+
+    pub(crate) fn expired_unmined(&self) -> bool {
+        self.expired_unmined
+    }
+
+    pub(crate) fn memo_count(&self) -> usize {
+        self.memo_count
+    }
+
+    pub(crate) fn is_shielding(&self) -> bool {
+        self.is_shielding
+    }
+}
+
+/// Trait used by tests that require a full viewing key.
+pub(crate) trait TestFvk {
+    type Nullifier: Copy;
+
+    fn sapling_ovk(&self) -> Option<sapling::keys::OutgoingViewingKey>;
+
+    #[cfg(feature = "orchard")]
+    fn orchard_ovk(&self, scope: zip32::Scope) -> Option<orchard::keys::OutgoingViewingKey>;
+
+    fn add_spend<R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        nf: Self::Nullifier,
+        rng: &mut R,
+    );
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_output<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        params: &P,
+        height: BlockHeight,
+        req: AddressType,
+        value: NonNegativeAmount,
+        initial_sapling_tree_size: u32,
+        // we don't require an initial Orchard tree size because we don't need it to compute
+        // the nullifier.
+        rng: &mut R,
+    ) -> Self::Nullifier;
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_logical_action<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        params: &P,
+        height: BlockHeight,
+        nf: Self::Nullifier,
+        req: AddressType,
+        value: NonNegativeAmount,
+        initial_sapling_tree_size: u32,
+        // we don't require an initial Orchard tree size because we don't need it to compute
+        // the nullifier.
+        rng: &mut R,
+    ) -> Self::Nullifier;
+}
+
+impl<'a, A: TestFvk> TestFvk for &'a A {
+    type Nullifier = A::Nullifier;
+
+    fn sapling_ovk(&self) -> Option<sapling::keys::OutgoingViewingKey> {
+        (*self).sapling_ovk()
+    }
+
+    #[cfg(feature = "orchard")]
+    fn orchard_ovk(&self, scope: zip32::Scope) -> Option<orchard::keys::OutgoingViewingKey> {
+        (*self).orchard_ovk(scope)
+    }
+
+    fn add_spend<R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        nf: Self::Nullifier,
+        rng: &mut R,
+    ) {
+        (*self).add_spend(ctx, nf, rng)
+    }
+
+    fn add_output<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        params: &P,
+        height: BlockHeight,
+        req: AddressType,
+        value: Zatoshis,
+        initial_sapling_tree_size: u32,
+        // we don't require an initial Orchard tree size because we don't need it to compute
+        // the nullifier.
+        rng: &mut R,
+    ) -> Self::Nullifier {
+        (*self).add_output(
+            ctx,
+            params,
+            height,
+            req,
+            value,
+            initial_sapling_tree_size,
+            rng,
+        )
+    }
+
+    fn add_logical_action<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        params: &P,
+        height: BlockHeight,
+        nf: Self::Nullifier,
+        req: AddressType,
+        value: Zatoshis,
+        initial_sapling_tree_size: u32,
+        // we don't require an initial Orchard tree size because we don't need it to compute
+        // the nullifier.
+        rng: &mut R,
+    ) -> Self::Nullifier {
+        (*self).add_logical_action(
+            ctx,
+            params,
+            height,
+            nf,
+            req,
+            value,
+            initial_sapling_tree_size,
+            rng,
+        )
+    }
+}
+
+impl TestFvk for DiversifiableFullViewingKey {
+    type Nullifier = Nullifier;
+
+    fn sapling_ovk(&self) -> Option<sapling::keys::OutgoingViewingKey> {
+        Some(self.fvk().ovk)
+    }
+
+    #[cfg(feature = "orchard")]
+    fn orchard_ovk(&self, _: zip32::Scope) -> Option<orchard::keys::OutgoingViewingKey> {
+        None
+    }
+
+    fn add_spend<R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        nf: Self::Nullifier,
+        _: &mut R,
+    ) {
+        let cspend = CompactSaplingSpend { nf: nf.to_vec() };
+        ctx.spends.push(cspend);
+    }
+
+    fn add_output<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        params: &P,
+        height: BlockHeight,
+        req: AddressType,
+        value: NonNegativeAmount,
+        initial_sapling_tree_size: u32,
+        rng: &mut R,
+    ) -> Self::Nullifier {
+        let recipient = match req {
+            AddressType::DefaultExternal => self.default_address().1,
+            AddressType::DiversifiedExternal(idx) => self.find_address(idx).unwrap().1,
+            AddressType::Internal => self.change_address().1,
+        };
+
+        let position = initial_sapling_tree_size + ctx.outputs.len() as u32;
+
+        let (cout, note) =
+            compact_sapling_output(params, height, recipient, value, self.sapling_ovk(), rng);
+        ctx.outputs.push(cout);
+
+        note.nf(&self.fvk().vk.nk, position as u64)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_logical_action<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        params: &P,
+        height: BlockHeight,
+        nf: Self::Nullifier,
+        req: AddressType,
+        value: NonNegativeAmount,
+        initial_sapling_tree_size: u32,
+        rng: &mut R,
+    ) -> Self::Nullifier {
+        self.add_spend(ctx, nf, rng);
+        self.add_output(
+            ctx,
+            params,
+            height,
+            req,
+            value,
+            initial_sapling_tree_size,
+            rng,
+        )
+    }
+}
+
+#[cfg(feature = "orchard")]
+impl TestFvk for orchard::keys::FullViewingKey {
+    type Nullifier = orchard::note::Nullifier;
+
+    fn sapling_ovk(&self) -> Option<sapling::keys::OutgoingViewingKey> {
+        None
+    }
+
+    fn orchard_ovk(&self, scope: zip32::Scope) -> Option<orchard::keys::OutgoingViewingKey> {
+        Some(self.to_ovk(scope))
+    }
+
+    fn add_spend<R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        revealed_spent_note_nullifier: Self::Nullifier,
+        rng: &mut R,
+    ) {
+        // Generate a dummy recipient.
+        let recipient = loop {
+            let mut bytes = [0; 32];
+            rng.fill_bytes(&mut bytes);
+            let sk = orchard::keys::SpendingKey::from_bytes(bytes);
+            if sk.is_some().into() {
+                break orchard::keys::FullViewingKey::from(&sk.unwrap())
+                    .address_at(0u32, zip32::Scope::External);
+            }
+        };
+
+        let (cact, _) = compact_orchard_action(
+            revealed_spent_note_nullifier,
+            recipient,
+            NonNegativeAmount::ZERO,
+            self.orchard_ovk(zip32::Scope::Internal),
+            rng,
+        );
+        ctx.actions.push(cact);
+    }
+
+    fn add_output<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        _: &P,
+        _: BlockHeight,
+        req: AddressType,
+        value: NonNegativeAmount,
+        _: u32, // the position is not required for computing the Orchard nullifier
+        mut rng: &mut R,
+    ) -> Self::Nullifier {
+        // Generate a dummy nullifier for the spend
+        let revealed_spent_note_nullifier =
+            orchard::note::Nullifier::from_bytes(&pallas::Base::random(&mut rng).to_repr())
+                .unwrap();
+
+        let (j, scope) = match req {
+            AddressType::DefaultExternal => (0u32.into(), zip32::Scope::External),
+            AddressType::DiversifiedExternal(idx) => (idx, zip32::Scope::External),
+            AddressType::Internal => (0u32.into(), zip32::Scope::Internal),
+        };
+
+        let (cact, note) = compact_orchard_action(
+            revealed_spent_note_nullifier,
+            self.address_at(j, scope),
+            value,
+            self.orchard_ovk(scope),
+            rng,
+        );
+        ctx.actions.push(cact);
+
+        note.nullifier(self)
+    }
+
+    // Override so we can merge the spend and output into a single action.
+    fn add_logical_action<P: consensus::Parameters, R: RngCore + CryptoRng>(
+        &self,
+        ctx: &mut CompactTx,
+        _: &P,
+        _: BlockHeight,
+        revealed_spent_note_nullifier: Self::Nullifier,
+        address_type: AddressType,
+        value: NonNegativeAmount,
+        _: u32, // the position is not required for computing the Orchard nullifier
+        rng: &mut R,
+    ) -> Self::Nullifier {
+        let (j, scope) = match address_type {
+            AddressType::DefaultExternal => (0u32.into(), zip32::Scope::External),
+            AddressType::DiversifiedExternal(idx) => (idx, zip32::Scope::External),
+            AddressType::Internal => (0u32.into(), zip32::Scope::Internal),
+        };
+
+        let (cact, note) = compact_orchard_action(
+            revealed_spent_note_nullifier,
+            self.address_at(j, scope),
+            value,
+            self.orchard_ovk(scope),
+            rng,
+        );
+        ctx.actions.push(cact);
+
+        // Return the nullifier of the newly created output note
+        note.nullifier(self)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum AddressType {
+    DefaultExternal,
+    #[allow(dead_code)]
+    DiversifiedExternal(DiversifierIndex),
+    Internal,
+}
+
+/// Creates a `CompactSaplingOutput` at the given height paying the given recipient.
+///
+/// Returns the `CompactSaplingOutput` and the new note.
+fn compact_sapling_output<P: consensus::Parameters, R: RngCore + CryptoRng>(
+    params: &P,
+    height: BlockHeight,
+    recipient: sapling::PaymentAddress,
+    value: NonNegativeAmount,
+    ovk: Option<sapling::keys::OutgoingViewingKey>,
+    rng: &mut R,
+) -> (CompactSaplingOutput, sapling::Note) {
+    let rseed = generate_random_rseed(zip212_enforcement(params, height), rng);
+    let note = Note::from_parts(
+        recipient,
+        sapling::value::NoteValue::from_raw(value.into_u64()),
+        rseed,
+    );
+    let encryptor = sapling_note_encryption(ovk, note.clone(), *MemoBytes::empty().as_array(), rng);
+    let cmu = note.cmu().to_bytes().to_vec();
+    let ephemeral_key = SaplingDomain::epk_bytes(encryptor.epk()).0.to_vec();
+    let enc_ciphertext = encryptor.encrypt_note_plaintext();
+
+    (
+        CompactSaplingOutput {
+            cmu,
+            ephemeral_key,
+            ciphertext: enc_ciphertext.as_ref()[..52].to_vec(),
+        },
+        note,
+    )
+}
+
+/// Creates a `CompactOrchardAction` at the given height paying the given recipient.
+///
+/// Returns the `CompactOrchardAction` and the new note.
+#[cfg(feature = "orchard")]
+fn compact_orchard_action<R: RngCore + CryptoRng>(
+    nf_old: orchard::note::Nullifier,
+    recipient: orchard::Address,
+    value: NonNegativeAmount,
+    ovk: Option<orchard::keys::OutgoingViewingKey>,
+    rng: &mut R,
+) -> (CompactOrchardAction, orchard::Note) {
+    use zcash_note_encryption::ShieldedOutput;
+
+    let (compact_action, note) = orchard::note_encryption::testing::fake_compact_action(
+        rng,
+        nf_old,
+        recipient,
+        orchard::value::NoteValue::from_raw(value.into_u64()),
+        ovk,
+    );
+
+    (
+        CompactOrchardAction {
+            nullifier: compact_action.nullifier().to_bytes().to_vec(),
+            cmx: compact_action.cmx().to_bytes().to_vec(),
+            ephemeral_key: compact_action.ephemeral_key().0.to_vec(),
+            ciphertext: compact_action.enc_ciphertext().as_ref()[..52].to_vec(),
+        },
+        note,
+    )
+}
+
+/// Creates a fake `CompactTx` with a random transaction ID and no spends or outputs.
+fn fake_compact_tx<R: RngCore + CryptoRng>(rng: &mut R) -> CompactTx {
+    let mut ctx = CompactTx::default();
+    let mut txid = vec![0; 32];
+    rng.fill_bytes(&mut txid);
+    ctx.hash = txid;
+
+    ctx
+}
+
+#[derive(Clone)]
+pub(crate) struct FakeCompactOutput<Fvk> {
+    fvk: Fvk,
+    address_type: AddressType,
+    value: NonNegativeAmount,
+}
+
+impl<Fvk> FakeCompactOutput<Fvk> {
+    pub(crate) fn new(fvk: Fvk, address_type: AddressType, value: NonNegativeAmount) -> Self {
+        Self {
+            fvk,
+            address_type,
+            value,
+        }
+    }
+}
+
+/// Create a fake CompactBlock at the given height, containing the specified fake compact outputs.
+///
+/// Returns the newly created compact block, along with the nullifier for each note created in that
+/// block.
+#[allow(clippy::too_many_arguments)]
+fn fake_compact_block<P: consensus::Parameters, Fvk: TestFvk>(
+    params: &P,
+    height: BlockHeight,
+    prev_hash: BlockHash,
+    outputs: &[FakeCompactOutput<Fvk>],
+    initial_sapling_tree_size: u32,
+    initial_orchard_tree_size: u32,
+    mut rng: impl RngCore + CryptoRng,
+) -> (CompactBlock, Vec<Fvk::Nullifier>) {
+    // Create a fake CompactBlock containing the note
+    let mut ctx = fake_compact_tx(&mut rng);
+    let mut nfs = vec![];
+    for output in outputs {
+        let nf = output.fvk.add_output(
+            &mut ctx,
+            params,
+            height,
+            output.address_type,
+            output.value,
+            initial_sapling_tree_size,
+            &mut rng,
+        );
+        nfs.push(nf);
+    }
+
+    let cb = fake_compact_block_from_compact_tx(
+        ctx,
+        height,
+        prev_hash,
+        initial_sapling_tree_size,
+        initial_orchard_tree_size,
+        rng,
+    );
+    (cb, nfs)
+}
+
+/// Create a fake CompactBlock at the given height containing only the given transaction.
+fn fake_compact_block_from_tx(
+    height: BlockHeight,
+    prev_hash: BlockHash,
+    tx_index: usize,
+    tx: &Transaction,
+    initial_sapling_tree_size: u32,
+    initial_orchard_tree_size: u32,
+    rng: impl RngCore,
+) -> CompactBlock {
+    // Create a fake CompactTx containing the transaction.
+    let mut ctx = CompactTx {
+        index: tx_index as u64,
+        hash: tx.txid().as_ref().to_vec(),
+        ..Default::default()
+    };
+
+    if let Some(bundle) = tx.sapling_bundle() {
+        for spend in bundle.shielded_spends() {
+            ctx.spends.push(spend.into());
+        }
+        for output in bundle.shielded_outputs() {
+            ctx.outputs.push(output.into());
+        }
+    }
+
+    #[cfg(feature = "orchard")]
+    if let Some(bundle) = tx.orchard_bundle() {
+        for action in bundle.actions() {
+            ctx.actions.push(action.into());
+        }
+    }
+
+    fake_compact_block_from_compact_tx(
+        ctx,
+        height,
+        prev_hash,
+        initial_sapling_tree_size,
+        initial_orchard_tree_size,
+        rng,
+    )
+}
+
+/// Create a fake CompactBlock at the given height, spending a single note from the
+/// given address.
+#[allow(clippy::too_many_arguments)]
+fn fake_compact_block_spending<P: consensus::Parameters, Fvk: TestFvk>(
+    params: &P,
+    height: BlockHeight,
+    prev_hash: BlockHash,
+    (nf, in_value): (Fvk::Nullifier, NonNegativeAmount),
+    fvk: &Fvk,
+    to: Address,
+    value: NonNegativeAmount,
+    initial_sapling_tree_size: u32,
+    initial_orchard_tree_size: u32,
+    mut rng: impl RngCore + CryptoRng,
+) -> CompactBlock {
+    let mut ctx = fake_compact_tx(&mut rng);
+
+    // Create a fake spend and a fake Note for the change
+    fvk.add_logical_action(
+        &mut ctx,
+        params,
+        height,
+        nf,
+        AddressType::Internal,
+        (in_value - value).unwrap(),
+        initial_sapling_tree_size,
+        &mut rng,
+    );
+
+    // Create a fake Note for the payment
+    match to {
+        Address::Sapling(recipient) => ctx.outputs.push(
+            compact_sapling_output(
+                params,
+                height,
+                recipient,
+                value,
+                fvk.sapling_ovk(),
+                &mut rng,
+            )
+            .0,
+        ),
+        Address::Transparent(_) | Address::Tex(_) => {
+            panic!("transparent addresses not supported in compact blocks")
+        }
+        Address::Unified(ua) => {
+            // This is annoying to implement, because the protocol-aware UA type has no
+            // concept of ZIP 316 preference order.
+            let mut done = false;
+
+            #[cfg(feature = "orchard")]
+            if let Some(recipient) = ua.orchard() {
+                // Generate a dummy nullifier
+                let nullifier =
+                    orchard::note::Nullifier::from_bytes(&pallas::Base::random(&mut rng).to_repr())
+                        .unwrap();
+
+                ctx.actions.push(
+                    compact_orchard_action(
+                        nullifier,
+                        *recipient,
+                        value,
+                        fvk.orchard_ovk(zip32::Scope::External),
+                        &mut rng,
+                    )
+                    .0,
+                );
+                done = true;
+            }
+
+            if !done {
+                if let Some(recipient) = ua.sapling() {
+                    ctx.outputs.push(
+                        compact_sapling_output(
+                            params,
+                            height,
+                            *recipient,
+                            value,
+                            fvk.sapling_ovk(),
+                            &mut rng,
+                        )
+                        .0,
+                    );
+                    done = true;
+                }
+            }
+            if !done {
+                panic!("No supported shielded receiver to send funds to");
+            }
+        }
+    }
+
+    fake_compact_block_from_compact_tx(
+        ctx,
+        height,
+        prev_hash,
+        initial_sapling_tree_size,
+        initial_orchard_tree_size,
+        rng,
+    )
+}
+
+fn fake_compact_block_from_compact_tx(
+    ctx: CompactTx,
+    height: BlockHeight,
+    prev_hash: BlockHash,
+    initial_sapling_tree_size: u32,
+    initial_orchard_tree_size: u32,
+    mut rng: impl RngCore,
+) -> CompactBlock {
+    let mut cb = CompactBlock {
+        hash: {
+            let mut hash = vec![0; 32];
+            rng.fill_bytes(&mut hash);
+            hash
+        },
+        height: height.into(),
+        ..Default::default()
+    };
+    cb.prev_hash.extend_from_slice(&prev_hash.0);
+    cb.vtx.push(ctx);
+    cb.chain_metadata = Some(compact::ChainMetadata {
+        sapling_commitment_tree_size: initial_sapling_tree_size
+            + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
+        orchard_commitment_tree_size: initial_orchard_tree_size
+            + cb.vtx.iter().map(|tx| tx.actions.len() as u32).sum::<u32>(),
+    });
+    cb
+}
+
+/// Trait used by tests that require a block cache.
+pub(crate) trait TestCache {
+    type BlockSource: BlockSource;
+    type InsertResult;
+
+    /// Exposes the block cache as a [`BlockSource`].
+    fn block_source(&self) -> &Self::BlockSource;
+
+    /// Inserts a CompactBlock into the cache DB.
+    fn insert(&self, cb: &CompactBlock) -> Self::InsertResult;
+}
+
 pub(crate) struct BlockCache {
     _cache_file: NamedTempFile,
     db_cache: BlockDb,

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -4,8 +4,8 @@ use std::fmt;
 use std::rc::Rc;
 
 use regex::Regex;
-use schemerz::{Migrator, MigratorError};
-use schemerz_rusqlite::RusqliteAdapter;
+use schemer::{Migrator, MigratorError};
+use schemer_rusqlite::RusqliteAdapter;
 use secrecy::SecretVec;
 use shardtree::error::ShardTreeError;
 use uuid::Uuid;

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -79,10 +79,6 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
     //              ------------------------------ tx_retrieval_queue ----------------------------
     //                                                     |
     //                                            support_legacy_sqlite
-    //                                                     |
-    //                                         fix_broken_commitment_trees
-    //                                                     |
-    //                                          fix_bad_change_flagging
     vec![
         Box::new(initial_setup::Migration {}),
         Box::new(utxos_table::Migration {}),
@@ -141,10 +137,6 @@ pub(super) fn all_migrations<P: consensus::Parameters + 'static>(
             params: params.clone(),
         }),
         Box::new(support_legacy_sqlite::Migration),
-        Box::new(fix_broken_commitment_trees::Migration {
-            params: params.clone(),
-        }),
-        Box::new(fix_bad_change_flagging::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/support_legacy_sqlite.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/support_legacy_sqlite.rs
@@ -1,7 +1,9 @@
 //! Modifies definitions to avoid keywords that may not be available in older SQLite versions.
 use std::collections::HashSet;
 
-use schemerz_rusqlite::RusqliteMigration;
+use rusqlite;
+use schemer;
+use schemer_rusqlite::RusqliteMigration;
 use uuid::Uuid;
 
 use crate::wallet::init::{migrations::tx_retrieval_queue, WalletMigrationError};
@@ -12,7 +14,7 @@ const DEPENDENCIES: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
 
 pub(super) struct Migration;
 
-impl schemerz::Migration<Uuid> for Migration {
+impl schemer::Migration for Migration {
     fn id(&self) -> Uuid {
         MIGRATION_ID
     }


### PR DESCRIPTION
Update audits for zcash_client_sqlite

Support older `sqlite` versions.

The `FALSE` constant was introduced in sqlite version 3.23.0, but Android does not support this version of sqlite until API level 30; we support back to Android API 27 so we have to use `0` as the constant for `FALSE` instead.

zcash_client_sqlite: Verify sqlite version compatibility on wallet init.

zcash_client_sqlite: Accept 2-part `major.minor` SQLite versions.

Release zcash_client_sqlite version 0.11.2

add Display for NoteId

set build server true

changes to 'calculate_proposed_transaction'

auto-generated build_server code

added hdwallet dep and finished create_proposed_transactions

updated rust version to 1.77.0

add .0 to rust version in Cargo.toml

add clone to zcash_address::encoding::ParseError

add clone to zcash_address::kind::unified::ParseError

add pub fn to return ua from ZcashAddress

add kind getter to ZcashAddress

change IVK decryption of build_result transaction to External

remove usk_to_tkey override

remove hdwallet dep